### PR TITLE
Setup for prod environments and check quota from associated wallets

### DIFF
--- a/components/event/Detail/EventSummary.tsx
+++ b/components/event/Detail/EventSummary.tsx
@@ -74,7 +74,6 @@ function EventSummary({
         .owner()
         .call()
         .then((result: any) => {
-          console.log("Check owner", result)
           setIsSmartContractOwner(result === address)
         })
         .catch(() => {

--- a/components/market/ticket/TicketPurchaseModal.tsx
+++ b/components/market/ticket/TicketPurchaseModal.tsx
@@ -68,7 +68,7 @@ function TicketPurchaseModal({ open, setOpen, ticket, event }: P) {
     const payload = {
       ticket: updatedTicket,
       ticketCollectionId: event.ticketCollectionId,
-      ownerId: address,
+      walletAddress: address,
       isTransactionUpdate: true
     }
     try {

--- a/configs/wagmi/client.ts
+++ b/configs/wagmi/client.ts
@@ -1,12 +1,14 @@
 import { getDefaultWallets } from "@rainbow-me/rainbowkit"
 import { chain, configureChains, createClient } from "wagmi"
-import { alchemyProvider } from "wagmi/providers/alchemy"
 import { publicProvider } from "wagmi/providers/public"
 
-const availableChains = [chain.polygon]
-if (process.env.NEXT_PUBLIC_ENABLE_TESTNET === "true") {
-  availableChains.push(chain.polygonMumbai)
-}
+let availableChains = [chain.polygon]
+if (process.env.NEXT_PUBLIC_WARDEN_ENVIRONMENT === "local")
+  availableChains = [chain.polygonMumbai]
+if (process.env.NEXT_PUBLIC_WARDEN_ENVIRONMENT === "staging")
+  availableChains = [chain.polygonMumbai]
+if (process.env.NEXT_PUBLIC_WARDEN_ENVIRONMENT === "production")
+  availableChains = [chain.polygon]
 
 const { chains, provider } = configureChains(availableChains, [
   publicProvider()

--- a/types/environment.d.ts
+++ b/types/environment.d.ts
@@ -1,6 +1,7 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
+      NEXT_PUBLIC_WARDEN_ENVIRONMENT: "local" | "staging" | "production"
       NEXT_PUBLIC_WARDEN_API_URL: string
       NEXT_PUBLIC_APP_URL: string
       NEXT_PUBLIC_ALCHEMY_KEY: string
@@ -13,7 +14,6 @@ declare global {
 
       NEXT_PUBLIC_POLYGONSCAN_URL: string
       NODE_ENV: "development" | "production"
-      ENABLE_TESTNET: "true" | "false"
     }
   }
 }


### PR DESCRIPTION
- [x]  !!! should include associated wallet used for purchase to the user mongo database as well, so we can confidently say that the purchaser identity is bound to a person
    - [x]  update `/ticket/transaction/permission` so it checks all of the user’s address related

Explanation
https://youtu.be/W_Hp8-3e3hQ